### PR TITLE
Eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,5 @@ parserOptions:
   ecmaVersion: 13
   sourceType: module
 rules: {
-  semi:
-    - error
-    - always
+  semi: error
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing a rule in the `.eslintrc.yml` file related to the usage of semicolons. 

### Detailed summary:
- Changed the rule for `semi` from an array to a single value
- Set the value of `semi` to `error`
- Removed the `always` option

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->