### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: Node.js Package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,11 +1,9 @@
 name: Node.js CI
-
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Closes #18 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a Node.js Package workflow that builds, tests, and publishes the package to the npm registry when a release is created.

### Detailed summary
- Added a new workflow file `.github/workflows/npm-publish.yml`
- Added a job `build` that runs on `ubuntu-20.04` and performs the following steps:
  - Checks out the code
  - Sets up Node.js version 16
  - Installs dependencies using `npm ci`
  - Runs tests using `npm test`
- Added a job `publish-npm` that runs on `ubuntu-latest` and performs the following steps:
  - Checks out the code
  - Sets up Node.js version 16 and specifies the npm registry URL
  - Installs dependencies using `npm ci`
  - Publishes the package using `npm publish`
- Added an environment variable `NODE_AUTH_TOKEN` to store the NPM token

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->