### PR TITLE
Script updated

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,19 +9,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - run: npm ci
-      - run: npm test
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
+          node-version: 18
+      - run: npm install
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN:  ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type_conversions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `type_conversions` package and changing the Node.js version in the GitHub Actions workflow.

### Detailed summary
- Updated the version of the `type_conversions` package from `0.1.3` to `0.1.4` in `package.json`.
- Changed the Node.js version from `16` to `18` in the GitHub Actions workflow (`npm-publish.yml`).
- Replaced `npm ci` with `npm install` in the GitHub Actions workflow.
- Updated the `NODE_AUTH_TOKEN` value in the GitHub Actions workflow to use the `secrets.NPM_TOKEN` secret.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->